### PR TITLE
Technic Plus compatibility (minimal)

### DIFF
--- a/chisel.lua
+++ b/chisel.lua
@@ -365,7 +365,9 @@ else -- technic is installed
 			return
 		end
 
-		local meta = minetest.deserialize(itemstack:get_metadata())
+		local meta = technic.plus
+			and { charge = technic.get_RE_charge(itemstack) }
+			or minetest.deserialize(itemstack:get_metadata())
 		if not meta or not meta.charge or
 				meta.charge < chisel_charge_per_node then
 			return


### PR DESCRIPTION
Minimal compatibility for Technic Plus.

This PR is for minimal changes with some drawbacks. Optional #9 for full compatibility but more LoC.

This will keep complaining about deprecated ItemStack functions and Technic Plus will also complain about deprecated power tool API.
Also will keep serializing and writing unnecessary itemstack metadata when using Technic Plus.